### PR TITLE
Fix example generation prompts

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,5 +1,20 @@
 import React, { useState, useEffect } from "react";
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert } from "react-native";
+import {
+  Select,
+  SelectTrigger,
+  SelectInput,
+  SelectIcon,
+  SelectPortal,
+  SelectBackdrop,
+  SelectContent,
+  SelectItem,
+  Slider,
+  SliderTrack,
+  SliderFilledTrack,
+  SliderThumb
+} from "@gluestack-ui/themed";
+import { ChevronDown } from "lucide-react-native";
 import { useStore } from "../src/ui/hooks/useStore";
 import { storage } from "../src/platform/storageUtils";
 import { ExampleGenerationMode, ModelOption } from "../src/ui/hooks/useStore";
@@ -147,36 +162,20 @@ export default function SettingsScreen() {
           Choose which AI model to use for generating examples and profiles.
         </Text>
 
-        {MODEL_OPTIONS.map((model, index) => (
-          <TouchableOpacity
-            key={model.key}
-            style={[
-              styles.modeOption,
-              selectedModel === model.key && styles.selectedMode,
-              index < MODEL_OPTIONS.length - 1 && styles.modeOptionMargin
-            ]}
-            onPress={() => changeModel(model.key)}
-          >
-            <View style={styles.modeContent}>
-              <Text style={[
-                styles.modeLabel,
-                selectedModel === model.key && styles.selectedModeText
-              ]}>
-                {model.label}
-              </Text>
-              <Text style={[
-                styles.modeDescription,
-                selectedModel === model.key && styles.selectedModeDescription
-              ]}>
-                {model.description}
-              </Text>
-            </View>
-            <View style={[
-              styles.radioCircle,
-              selectedModel === model.key && styles.selectedRadio
-            ]} />
-          </TouchableOpacity>
-        ))}
+        <Select selectedValue={selectedModel} onValueChange={value => changeModel(value as ModelOption)}>
+          <SelectTrigger>
+            <SelectInput placeholder="Select model" />
+            <SelectIcon><ChevronDown size={16} /></SelectIcon>
+          </SelectTrigger>
+          <SelectPortal>
+            <SelectBackdrop />
+            <SelectContent>
+              {MODEL_OPTIONS.map(option => (
+                <SelectItem key={option.key} label={option.label} value={option.key} />
+              ))}
+            </SelectContent>
+          </SelectPortal>
+        </Select>
       </View>
 
       <View style={styles.section}>
@@ -185,36 +184,26 @@ export default function SettingsScreen() {
           Choose how examples are generated when you have few or no learned words.
         </Text>
 
-        {GENERATION_MODES.map((mode, index) => (
-          <TouchableOpacity
-            key={mode.key}
-            style={[
-              styles.modeOption,
-              exampleGenerationMode === mode.key && styles.selectedMode,
-              index < GENERATION_MODES.length - 1 && styles.modeOptionMargin
-            ]}
-            onPress={() => changeGenerationMode(mode.key)}
-          >
-            <View style={styles.modeContent}>
-              <Text style={[
-                styles.modeLabel,
-                exampleGenerationMode === mode.key && styles.selectedModeText
-              ]}>
-                {mode.label}
-              </Text>
-              <Text style={[
-                styles.modeDescription,
-                exampleGenerationMode === mode.key && styles.selectedModeDescription
-              ]}>
-                {mode.description}
-              </Text>
-            </View>
-            <View style={[
-              styles.radioCircle,
-              exampleGenerationMode === mode.key && styles.selectedRadio
-            ]} />
-          </TouchableOpacity>
-        ))}
+        <Slider
+          minValue={0}
+          maxValue={GENERATION_MODES.length - 1}
+          step={1}
+          value={GENERATION_MODES.findIndex(m => m.key === exampleGenerationMode)}
+          onChange={val => changeGenerationMode(GENERATION_MODES[val].key)}
+        >
+          <SliderTrack>
+            <SliderFilledTrack />
+          </SliderTrack>
+          <SliderThumb />
+        </Slider>
+        <View style={{ marginTop: 12 }}>
+          <Text style={styles.modeLabel}>
+            {GENERATION_MODES.find(m => m.key === exampleGenerationMode)?.label}
+          </Text>
+          <Text style={styles.modeDescription}>
+            {GENERATION_MODES.find(m => m.key === exampleGenerationMode)?.description}
+          </Text>
+        </View>
       </View>
 
       <View style={styles.section}>
@@ -305,24 +294,6 @@ const styles = StyleSheet.create({
     color: '#6b7280',
     marginBottom: 4,
   },
-  modeOption: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 12,
-    borderWidth: 2,
-    borderColor: '#e5e7eb',
-    borderRadius: 8,
-  },
-  modeOptionMargin: {
-    marginBottom: 8,
-  },
-  selectedMode: {
-    borderColor: '#3b82f6',
-    backgroundColor: '#eff6ff',
-  },
-  modeContent: {
-    flex: 1,
-  },
   modeLabel: {
     fontSize: 16,
     fontWeight: '600',
@@ -332,22 +303,4 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#6b7280',
   },
-  selectedModeText: {
-    color: '#3b82f6',
-  },
-  selectedModeDescription: {
-    color: '#2563eb',
-  },
-  radioCircle: {
-    width: 20,
-    height: 20,
-    borderRadius: 10,
-    borderWidth: 2,
-    borderColor: '#e5e7eb',
-    marginLeft: 12,
-  },
-  selectedRadio: {
-    backgroundColor: '#3b82f6',
-    borderColor: '#3b82f6',
-  },
-}); 
+});

--- a/src/infra/llm/togetherAdapter.ts
+++ b/src/infra/llm/togetherAdapter.ts
@@ -125,7 +125,7 @@ Return as JSON only.`;
     }
   }
 
-  async generateSentence(knownWords: string[], mode: ExampleGenerationMode = 'strict'): Promise<GeneratedSentence> {
+  async generateSentence(target: Word, knownWords: string[], mode: ExampleGenerationMode = 'strict'): Promise<GeneratedSentence> {
     let systemPrompt: string;
     let userPrompt: string;
 
@@ -138,14 +138,14 @@ Return as JSON only.`;
           throw new Error("Need at least 3 known words to generate meaningful sentences");
         }
         
-        const wordList = knownWords.join("，");
+        const wordList = [target.hanzi, ...knownWords].join("，");
         systemPrompt = `You are a concise Chinese tutor.
 Return ONLY valid JSON in this exact format:
 {"hanzi":"...", "pinyin":"...", "gloss":"..."}
 Do NOT include any other text, markdown, or explanation.`;
-        
+
         userPrompt = `Create ONE natural Chinese sentence using ONLY these words: [${wordList}].
-The sentence should be less than 30 characters.
+The sentence must include the target word “${target.hanzi}” meaning "${target.meaning}" and be less than 30 characters.
 Return the result as JSON with hanzi (Chinese characters), pinyin (with tone marks), and gloss (English translation).`;
         break;
 
@@ -154,9 +154,9 @@ Return the result as JSON with hanzi (Chinese characters), pinyin (with tone mar
         systemPrompt = `You are a Chinese tutor.
 Return ONLY valid JSON in this exact format:
 {"hanzi":"...", "pinyin":"...", "gloss":"..."}`;
-        
-        userPrompt = `Create a simple Chinese sentence. You may use these known words: [${someWordList}].
-You can add 1-2 additional common Chinese words if needed for natural flow.
+
+        userPrompt = `Create a simple Chinese sentence using the word “${target.hanzi}” ("${target.meaning}").
+You may also use these known words: [${someWordList}] and add 1-2 additional common Chinese words if needed.
 Keep it under 30 characters. Return as JSON with hanzi, pinyin, and gloss.`;
         break;
 
@@ -165,9 +165,9 @@ Keep it under 30 characters. Return as JSON with hanzi, pinyin, and gloss.`;
         systemPrompt = `You are a Chinese tutor.
 Return ONLY valid JSON in this exact format:
 {"hanzi":"...", "pinyin":"...", "gloss":"..."}`;
-        
-        userPrompt = `Create a natural Chinese sentence. You may reference these words: [${manyWordList}].
-Feel free to use additional common Chinese words to create a meaningful sentence.
+
+        userPrompt = `Create a natural Chinese sentence that uses the word “${target.hanzi}” ("${target.meaning}").
+You may reference these words: [${manyWordList}] and feel free to use additional common words to create a meaningful sentence.
 Keep it under 30 characters. Return as JSON with hanzi, pinyin, and gloss.`;
         break;
 
@@ -175,9 +175,9 @@ Keep it under 30 characters. Return as JSON with hanzi, pinyin, and gloss.`;
         systemPrompt = `You are a Chinese tutor creating beginner-friendly content.
 Return ONLY valid JSON in this exact format:
 {"hanzi":"...", "pinyin":"...", "gloss":"..."}`;
-        
-        userPrompt = `Create a simple, beginner-friendly Chinese sentence using common everyday words.
-Keep it under 20 characters and suitable for beginners.
+
+        userPrompt = `Create a simple, beginner-friendly Chinese sentence that includes the word “${target.hanzi}” ("${target.meaning}").
+Feel free to use any other common words. Keep it under 20 characters.
 Return as JSON with hanzi (Chinese characters), pinyin (with tone marks), and gloss (English translation).`;
         break;
 


### PR DESCRIPTION
## Summary
- ensure target word is included when generating example sentences
- teach TogetherAdapter about the target word in all generation modes
- switch settings screen to dropdown model picker and slider for mode

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*