### PR TITLE
Add Azure TTS for word profiles

### DIFF
--- a/app/profile/[id].tsx
+++ b/app/profile/[id].tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { View, Text, TouchableOpacity, ActivityIndicator, ScrollView, Dimensions } from "react-native";
+import * as Speech from "expo-speech"; // fallback
+import { speakWithAzure } from "../../src/infra/tts/azureTts";
 import { 
   Card, 
   Badge,
@@ -119,6 +121,22 @@ export default function WordProfileScreen() {
     }
   };
 
+  const speakWord = async () => {
+    if (word) {
+      const success = await speakWithAzure(word.hanzi);
+      if (!success) {
+        Speech.speak(word.hanzi, { language: 'zh-CN' });
+      }
+    }
+  };
+
+  const speakExample = async (text: string) => {
+    const success = await speakWithAzure(text);
+    if (!success) {
+      Speech.speak(text, { language: 'zh-CN' });
+    }
+  };
+
   if (!word) {
     return (
       <View className="flex-1 justify-center items-center p-4 bg-gray-50">
@@ -190,7 +208,10 @@ export default function WordProfileScreen() {
           <TouchableOpacity className="flex-1 bg-blue-600 py-3 rounded-lg items-center">
             <Text className="text-white font-semibold">Practice</Text>
           </TouchableOpacity>
-          <TouchableOpacity className="flex-1 bg-gray-200 py-3 rounded-lg items-center">
+          <TouchableOpacity
+            className="flex-1 bg-gray-200 py-3 rounded-lg items-center"
+            onPress={speakWord}
+          >
             <Text className="text-gray-700 font-semibold">Listen</Text>
           </TouchableOpacity>
           <TouchableOpacity className="bg-gray-200 p-3 rounded-lg">
@@ -306,11 +327,15 @@ export default function WordProfileScreen() {
               
               <View className="space-y-4">
                 {profile.exampleSentences.map((example, index) => (
-                  <View key={index} className="bg-gray-50 p-4 rounded-lg border border-gray-100">
+                  <TouchableOpacity
+                    key={index}
+                    className="bg-gray-50 p-4 rounded-lg border border-gray-100"
+                    onPress={() => speakExample(example.hanzi)}
+                  >
                     <Text className="text-lg font-semibold text-gray-900 mb-1">{example.hanzi}</Text>
                     <Text className="text-blue-600 mb-2">{example.pinyin}</Text>
                     <Text className="text-gray-700 italic">{example.gloss}</Text>
-                  </View>
+                  </TouchableOpacity>
                 ))}
               </View>
             </View>

--- a/env.ts
+++ b/env.ts
@@ -2,3 +2,9 @@ import Constants from "expo-constants";
 
 export const TOGETHER_KEY =
   (Constants.expoConfig?.extra as any)?.TOGETHER_API_KEY ?? "";
+
+export const AZURE_TTS_KEY =
+  (Constants.expoConfig?.extra as any)?.AZURE_TTS_KEY ?? "";
+
+export const AZURE_TTS_REGION =
+  (Constants.expoConfig?.extra as any)?.AZURE_TTS_REGION ?? "";

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "expo-linking": "^7.1.5",
     "expo-router": "~5.0.7",
     "expo-sqlite": "~15.2.10",
+    "expo-av": "~13.2.1",
+    "expo-speech": "^12.5.0",
     "expo-status-bar": "~2.2.3",
     "lucide-react": "^0.511.0",
     "lucide-react-native": "^0.511.0",

--- a/src/infra/tts/azureTts.ts
+++ b/src/infra/tts/azureTts.ts
@@ -1,0 +1,68 @@
+import { Audio } from 'expo-av';
+import { AZURE_TTS_KEY, AZURE_TTS_REGION } from '../../../env';
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  // Use global btoa if available, otherwise fallback to Buffer
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  // @ts-ignore Buffer may not exist in all environments
+  return Buffer.from(binary, 'binary').toString('base64');
+}
+
+export async function speakWithAzure(text: string, voice = 'zh-CN-XiaoxiaoNeural'): Promise<boolean> {
+  if (!AZURE_TTS_KEY || !AZURE_TTS_REGION) {
+    console.warn('Azure TTS credentials not configured');
+    return false;
+  }
+
+  try {
+    // Acquire auth token
+    const tokenRes = await fetch(
+      `https://${AZURE_TTS_REGION}.api.cognitive.microsoft.com/sts/v1.0/issuetoken`,
+      {
+        method: 'POST',
+        headers: {
+          'Ocp-Apim-Subscription-Key': AZURE_TTS_KEY,
+          'Content-Length': '0',
+        },
+      }
+    );
+    if (!tokenRes.ok) {
+      throw new Error('Failed to fetch Azure auth token');
+    }
+    const token = await tokenRes.text();
+
+    const ssml = `<?xml version='1.0' encoding='utf-8'?><speak version='1.0' xml:lang='zh-CN'><voice name='${voice}'>${text}</voice></speak>`;
+
+    const res = await fetch(
+      `https://${AZURE_TTS_REGION}.tts.speech.microsoft.com/cognitiveservices/v1`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/ssml+xml',
+          'X-Microsoft-OutputFormat': 'audio-24khz-48kbitrate-mono-mp3',
+        },
+        body: ssml,
+      }
+    );
+    if (!res.ok) {
+      throw new Error('Failed to generate speech');
+    }
+    const audioBuffer = await res.arrayBuffer();
+    const base64 = arrayBufferToBase64(audioBuffer);
+    const uri = `data:audio/mp3;base64,${base64}`;
+    const { sound } = await Audio.Sound.createAsync({ uri });
+    await sound.playAsync();
+    return true;
+  } catch (err) {
+    console.error('Azure TTS error', err);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- integrate Azure Speech API
- fallback to expo-speech if Azure is not configured
- allow speaking words and examples with high-quality TTS
- expose Azure TTS credentials via `env.ts`
- add `expo-av` dependency for audio playback

## Testing
- `npx tsc` *(fails: Cannot find modules)*