### PR TITLE
Improve flashcard review flow

### DIFF
--- a/src/ui/hooks/useFlashcardLogic.ts
+++ b/src/ui/hooks/useFlashcardLogic.ts
@@ -12,6 +12,7 @@ export const useFlashcardLogic = () => {
     getNextCard,
     reviewWord,
     advanceSession,
+    requeueCard,
     updateReviewSettings,
     setReviewMode,
     isLoading,
@@ -56,8 +57,12 @@ export const useFlashcardLogic = () => {
 
     setIsReviewing(true);
     try {
-      await reviewWord(currentCard.id, quality);
+      const updatedCard = await reviewWord(currentCard.id, quality);
       advanceSession();
+
+      if (quality === 'again' || updatedCard.status === 'learning') {
+        requeueCard(updatedCard);
+      }
 
       const nextCard = getNextCard();
       setCurrentCard(nextCard);

--- a/src/ui/hooks/useStore.ts
+++ b/src/ui/hooks/useStore.ts
@@ -16,6 +16,15 @@ import { DEFAULT_REVIEW_SETTINGS } from "../../domain/srs";
 // Import 300 words from CSV data
 import wordsData from '../../data/words_import.json';
 
+function shuffleArray<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
 export type ExampleGenerationMode = 'strict' | 'some-ood' | 'many-ood' | 'independent';
 
 export type ModelOption = 'deepseek-ai/DeepSeek-V3' | 'meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo' | 'Qwen/Qwen2.5-72B-Instruct-Turbo';
@@ -49,7 +58,7 @@ interface WeiLangStore {
   loadWords: () => Promise<void>;
   loadDueWords: () => Promise<void>;
   addWord: (params: { hanzi: string; pinyin: string; meaning: string }) => Promise<void>;
-  reviewWord: (wordId: string, quality: ReviewQuality) => Promise<void>;
+  reviewWord: (wordId: string, quality: ReviewQuality) => Promise<Word>;
   deleteWord: (wordId: string) => Promise<void>;
   setApiKey: (key: string | null) => void;
   clearError: () => void;
@@ -65,6 +74,7 @@ interface WeiLangStore {
   startReviewSession: (mode: ReviewMode) => Promise<void>;
   getNextCard: () => Word | null;
   advanceSession: () => void;
+  requeueCard: (card: Word) => void;
   updateReviewSettings: (settings: Partial<ReviewSettings>) => void;
   setReviewMode: (mode: ReviewMode) => void;
 }
@@ -207,11 +217,13 @@ export const useStore = create<WeiLangStore>((set, get) => {
         const words = get().words.map(w => w.id === wordId ? updatedWord : w);
         const dueWords = get().dueWords.filter(w => w.id !== wordId);
         set({ words, dueWords, isLoading: false });
+        return updatedWord;
       } catch (error) {
-        set({ 
+        set({
           error: error instanceof Error ? error.message : "Failed to review word",
-          isLoading: false 
+          isLoading: false
         });
+        throw error;
       }
     },
 
@@ -415,7 +427,7 @@ export const useStore = create<WeiLangStore>((set, get) => {
           batchCards.push(...session.reviewCards.slice(0, finalSpace));
         }
         
-        session.currentBatch = batchCards;
+        session.currentBatch = shuffleArray(batchCards);
         
         console.log('Session created:', {
           mode,
@@ -458,6 +470,20 @@ export const useStore = create<WeiLangStore>((set, get) => {
       };
       
       set({ currentSession: updatedSession });
+    },
+
+    requeueCard: (card: Word) => {
+      const session = get().currentSession;
+      if (!session) return;
+
+      const insertIndex = Math.min(
+        session.currentBatch.length,
+        Math.floor(Math.random() * 3) + 1
+      );
+      const newBatch = [...session.currentBatch];
+      newBatch.splice(insertIndex, 0, card);
+
+      set({ currentSession: { ...session, currentBatch: newBatch } });
     },
     
     updateReviewSettings: (newSettings: Partial<ReviewSettings>) => {


### PR DESCRIPTION
## Summary
- randomize initial flashcard order
- re-queue cards graded "again" so batches loop until mastered
- persist learning cards in the batch until they graduate

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: expo tsconfig missing)*