### PR TITLE
Fix character breakdown and web SQLite bundling

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -7,4 +7,6 @@ const config = getDefaultConfig(__dirname);
 config.resolver.alias = {
   "@": "./src",
 };
+// Support WASM modules needed for expo-sqlite on web
+config.resolver.assetExts.push('wasm');
 module.exports = withNativeWind(config, { input: "./global.css" }); 

--- a/src/ui/components/profile/tabs/BreakdownTab.tsx
+++ b/src/ui/components/profile/tabs/BreakdownTab.tsx
@@ -82,7 +82,7 @@ export function BreakdownTab() {
                     word.pinyin.split(' ')[index] || charData.pinyin : charData.pinyin}
                 </Text>
                 <Text className="text-base text-gray-700 text-center">
-                  {index === 0 ? word.meaning.split(',')[0] || word.meaning : charData.meaning}
+                  {charData.meaning}
                 </Text>
               </View>
             </View>


### PR DESCRIPTION
## Summary
- add WASM asset configuration to metro bundler for web SQLite support

## Testing
- `npm test` *(fails: Missing script)*