### PR TITLE
Add initial Android streak widget

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.yourname.weilang">
+    <application>
+        <receiver android:name=".widgets.StreakWidgetProvider" android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data android:name="android.appwidget.provider"
+                android:resource="@xml/streak_widget_info" />
+        </receiver>
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/yourname/weilang/widgets/StreakWidgetModule.kt
+++ b/android/app/src/main/java/com/yourname/weilang/widgets/StreakWidgetModule.kt
@@ -1,0 +1,31 @@
+package com.yourname.weilang.widgets
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.widget.RemoteViews
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.module.annotations.ReactModule
+import com.yourname.weilang.R
+
+@ReactModule(name = StreakWidgetModule.NAME)
+class StreakWidgetModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+    companion object {
+        const val NAME = "StreakWidget"
+    }
+
+    override fun getName() = NAME
+
+    @ReactMethod
+    fun updateStreak(streak: Int) {
+        val manager = AppWidgetManager.getInstance(reactContext)
+        val component = ComponentName(reactContext, StreakWidgetProvider::class.java)
+        val ids = manager.getAppWidgetIds(component)
+        for (id in ids) {
+            val views = RemoteViews(reactContext.packageName, R.layout.streak_widget)
+            views.setTextViewText(R.id.streak_text, "$streak day streak")
+            manager.updateAppWidget(id, views)
+        }
+    }
+}

--- a/android/app/src/main/java/com/yourname/weilang/widgets/StreakWidgetProvider.kt
+++ b/android/app/src/main/java/com/yourname/weilang/widgets/StreakWidgetProvider.kt
@@ -1,0 +1,16 @@
+package com.yourname.weilang.widgets
+
+import android.appwidget.AppWidgetProvider
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.widget.RemoteViews
+import com.yourname.weilang.R
+
+class StreakWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        for (widgetId in appWidgetIds) {
+            val views = RemoteViews(context.packageName, R.layout.streak_widget)
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/res/layout/streak_widget.xml
+++ b/android/app/src/main/res/layout/streak_widget.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp"
+    android:background="@android:color/white">
+    <TextView
+        android:id="@+id/streak_text"
+        android:text="0 day streak"
+        android:textSize="16sp"
+        android:textColor="@android:color/black" />
+</LinearLayout>

--- a/android/app/src/main/res/xml/streak_widget_info.xml
+++ b/android/app/src/main/res/xml/streak_widget_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="40dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/streak_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,6 +5,7 @@ import { useStore } from "../src/ui/hooks/useStore";
 import { BookOpen, Brain, BarChart3, Settings, Calendar, Trophy, Target, Languages } from "lucide-react-native";
 import { useThemedStyles, useTheme } from "../src/ui/theme";
 import { Text, Button, Card, Screen } from "../src/ui/components/themed";
+import { updateStreakWidget } from "../src/platform/streakWidget";
 
 export default function DashboardScreen() {
   const router = useRouter();
@@ -284,6 +285,10 @@ export default function DashboardScreen() {
       weeklyProgress,
       accuracy,
     });
+
+    if (Platform.OS === 'android') {
+      updateStreakWidget(currentStreak);
+    }
   }, [words, dueWords]);
 
   const navigationCards = [

--- a/src/platform/streakWidget.ts
+++ b/src/platform/streakWidget.ts
@@ -1,0 +1,20 @@
+import { NativeModules, Platform } from 'react-native'
+
+interface StreakWidgetModule {
+  updateStreak(streak: number): void
+}
+
+const LINKING_ERROR =
+  `The StreakWidget native module is not linked properly.`
+
+const Module = Platform.OS === 'android' && NativeModules.StreakWidget
+  ? (NativeModules.StreakWidget as StreakWidgetModule)
+  : null
+
+export function updateStreakWidget(streak: number): void {
+  if (Module) {
+    Module.updateStreak(streak)
+  } else if (__DEV__) {
+    console.warn(LINKING_ERROR)
+  }
+}


### PR DESCRIPTION
## Summary
- create Android widget provider and module to display streak
- expose `updateStreakWidget` from JS
- invoke widget update in dashboard screen

## Testing
- `npm test` *(fails: Missing script)*